### PR TITLE
Avoid repeated message from AllowCardReading

### DIFF
--- a/cardcomm/pkcs11/src/object.c
+++ b/cardcomm/pkcs11/src/object.c
@@ -333,7 +333,7 @@ CK_RV C_FindObjectsInit(CK_SESSION_HANDLE hSession,   /* the session's handle */
 		}
 		if((filesToCacheFlag != CACHED_DATA_TYPE_CARDDATA) && (filesToCacheFlag != CACHED_DATA_TYPE_RNCERT))
 		{
-			if ((pSession->bReadDataAllowed == P11_READDATA_ASK) & (eidmw_readpermission != P11_READDATA_ALWAYS))
+			if ((pSession->bReadDataAllowed == P11_READDATA_ASK) && (eidmw_readpermission != P11_READDATA_ALWAYS))
 			{
 				allowCardRead = AllowCardReading();
 				switch(allowCardRead)


### PR DESCRIPTION
Avoid to have the same AllowCardReading message each time the card is read : Simple operator correction.